### PR TITLE
feat: add GET /wishlists/<id> endpoint to read wishlist by ID

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -44,3 +44,12 @@ def index():
 ######################################################################
 
 # Todo: Place your REST API code here ...
+
+@app.route("/wishlists/<int:wishlist_id>", methods=["GET"])
+def get_wishlist(wishlist_id):
+    """Read a wishlist by ID"""
+    app.logger.info(f"Request to read wishlist with id: {wishlist_id}")
+    wishlist = YourResourceModel.find(wishlist_id)
+    if not wishlist:
+        return jsonify({"error": f"Wishlist with id {wishlist_id} was not found."}), status.HTTP_404_NOT_FOUND
+    return jsonify(wishlist.serialize()), status.HTTP_200_OK


### PR DESCRIPTION
### Description

This PR implements the "Read Wishlist API" feature.  
- Adds a GET endpoint at `/wishlists/<id>` to retrieve a wishlist by its ID.
- Returns a 200 OK response with the wishlist details in JSON if the wishlist exists.
- Returns a 404 Not Found with a JSON error message if the wishlist does not exist.

#### Acceptance Criteria
- [x] GET `/wishlists/123` returns 200 and wishlist details if ID 123 exists.
- [x] GET `/wishlists/9999` returns 404 and a JSON error if ID 9999 does not exist.

This addresses #3.

---

Let me know if you want to add or change anything!