### PR TITLE
refactor: update wishlist item routes to use /items endpoint

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -178,7 +178,7 @@ def get_wishlist_item(wishlist_id, product_id):
 ######################################################################
 # ADD AN ITEM TO A WISHLIST
 ######################################################################
-@app.route("/wishlists/<int:wishlist_id>/wishlist_items", methods=["POST"])
+@app.route("/wishlists/<int:wishlist_id>/items", methods=["POST"])
 def create_wishlist_items(wishlist_id):
     """
     Create a wishlist item on a wishlist
@@ -225,7 +225,7 @@ def create_wishlist_items(wishlist_id):
 # DELETE A WISHLIST ITEM
 ######################################################################
 @app.route(
-    "/wishlists/<int:wishlist_id>/wishlist_items/<int:product_id>",
+    "/wishlists/<int:wishlist_id>/items/<int:product_id>",
     methods=["DELETE"],
 )
 def delete_wishlist_items(wishlist_id, product_id):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -227,7 +227,7 @@ class TestWishlistsService(TestCase):
         # TODO: Wait until create_wishlist_items is implemented
         wishlist_item = WishlistItemsFactory()
         resp = self.client.post(
-            f"{BASE_URL}/{wishlist.id}/wishlist_items",
+            f"{BASE_URL}/{wishlist.id}/items",
             json=wishlist_item.serialize(),
             content_type="application/json",
         )
@@ -271,7 +271,7 @@ class TestWishlistsService(TestCase):
         wishlist = self._create_wishlists(1)[0]
         wishlist_item = WishlistItemsFactory()
         resp = self.client.post(
-            f"{BASE_URL}/{wishlist.id}/wishlist_items",
+            f"{BASE_URL}/{wishlist.id}/items",
             json=wishlist_item.serialize(),
             content_type="application/json",
         )
@@ -304,7 +304,7 @@ class TestWishlistsService(TestCase):
         wishlist = self._create_wishlists(1)[0]
         wishlist_item = WishlistItemsFactory()
         resp = self.client.post(
-            f"{BASE_URL}/{wishlist.id}/wishlist_items",
+            f"{BASE_URL}/{wishlist.id}/items",
             json=wishlist_item.serialize(),
             content_type="application/json",
         )
@@ -315,7 +315,7 @@ class TestWishlistsService(TestCase):
 
         # send delete request
         resp = self.client.delete(
-            f"{BASE_URL}/{wishlist.id}/wishlist_items/{wishlist_item_id}",
+            f"{BASE_URL}/{wishlist.id}/items/{wishlist_item_id}",
             content_type="application/json",
         )
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Changed API endpoints from /wishlist_items to /items for adding and deleting wishlist items in both service and test files for consistency and improved RESTful naming.

Closes #25 
