### PR TITLE
Add update wishlist endpoint and tests

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -84,6 +84,29 @@ def create_wishlists():
 
     return jsonify(message), status.HTTP_201_CREATED, {"Location": location_url}
 
+######################################################################
+# UPDATE WISHLISTS
+######################################################################
+@app.route("/wishlists/<int:wishlist_id>", methods=["PUT"])
+def update_wishlist(wishlist_id):
+    app.logger.info("Request to update wishlist with id: %s", wishlist_id)
+    
+    wishlist = Wishlists.find_by_id(wishlist_id)
+    if not wishlist:
+        abort(status.HTTP_404_NOT_FOUND, f"Wishlist with id '{wishlist_id}' was not found.")
+    
+    if wishlist.customer_id != STATE_CUSTOMER_ID:
+        abort(status.HTTP_403_FORBIDDEN, f"You do not have permission to update this wishlist.")
+    
+    data = request.get_json()
+    try:
+        wishlist.deserialize(data)
+        wishlist.update()
+    except DataValidationError as error:
+        abort(status.HTTP_400_BAD_REQUEST, str(error))
+    
+    return jsonify(wishlist.serialize()), status.HTTP_200_OK
+
 
 ######################################################################
 # RETRIEVE A WISHLIST


### PR DESCRIPTION
Implemented a PUT /wishlists/<id> route to update wishlists with validation and permission checks. Added corresponding tests for successful update, not found, forbidden, and bad request scenarios.