### PR TITLE
debeg checkid for issue#32

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -118,21 +118,42 @@ def create_wishlists():
 @app.route("/wishlists/<int:wishlist_id>", methods=["PUT"])
 def update_wishlist(wishlist_id):
     app.logger.info("Request to update wishlist with id: %s", wishlist_id)
-    
+
     wishlist = Wishlists.find_by_id(wishlist_id)
     if not wishlist:
-        abort(status.HTTP_404_NOT_FOUND, f"Wishlist with id '{wishlist_id}' was not found.")
-    
+        abort(status.HTTP_404_NOT_FOUND,
+              description=f"Wishlist with id '{wishlist_id}' was not found.")
+
     if wishlist.customer_id != STATE_CUSTOMER_ID:
-        abort(status.HTTP_403_FORBIDDEN, f"You do not have permission to update this wishlist.")
-    
-    data = request.get_json()
+        abort(status.HTTP_403_FORBIDDEN,
+              description="You do not have permission to update this wishlist.")
+
+    data = request.get_json(silent=True)
+    if data is None:
+        abort(status.HTTP_400_BAD_REQUEST,
+              description="Invalid or missing JSON body. Set Content-Type: application/json.")
+
+    # Verify that body.id is consistent with the URL (including type safety)
+    if "id" in data:
+        try:
+            if int(data["id"]) != int(wishlist_id):
+                abort(status.HTTP_400_BAD_REQUEST,
+                      description=f"Wishlist ID in body ({data['id']}) does not match ID in URL ({wishlist_id}).")
+        except (TypeError, ValueError):
+            abort(status.HTTP_400_BAD_REQUEST,
+                  description="Field 'id' must be an integer.")
+        # Avoid overwriting primary keys during deserialization
+        data.pop("id", None)
+
+    # Always ignore the visiting customer_id: force it to the original value in the database to prevent unauthorized access
+    data["customer_id"] = wishlist.customer_id
+
     try:
         wishlist.deserialize(data)
         wishlist.update()
     except DataValidationError as error:
-        abort(status.HTTP_400_BAD_REQUEST, str(error))
-    
+        abort(status.HTTP_400_BAD_REQUEST, description=str(error))
+
     return jsonify(wishlist.serialize()), status.HTTP_200_OK
 
 


### PR DESCRIPTION
1. It has been solved:
    The path ID does not match the body ID → 400;
    The visiting customer_id is ignored (forced to be the original owner), eliminating the risk of overstepping authority;
    Potential issues with the usage of abort, empty JSON, type safety, and deserialization overrides.

2. Also 
    Updated tests to cover the latest code logic