### PR TITLE
Implement customer_id and name filtering for list wishlists

### DIFF
--- a/service/models/wishlists.py
+++ b/service/models/wishlists.py
@@ -105,6 +105,14 @@ class Wishlists(db.Model, PersistentBase):
         return cls.query.filter(cls.customer_id == customer_id).all()
 
     @classmethod
+    def find_all_by_customer_id_and_name_like(cls, customer_id: int, name: int):
+        """Find all Wishlists for a given customer where the name contains the given substring (case-insensitive)."""
+        pattern = f"%{name}%"
+        return cls.query.filter(
+            cls.customer_id == customer_id, cls.name.ilike(pattern)
+        ).all()
+
+    @classmethod
     def reposition(cls, wishlist_id: int):
         """Reposition items in a Wishlist to ensure positions are sequential starting from 1000, with increments of 1000"""
         wishlist = cls.find_by_id(wishlist_id)

--- a/service/routes.py
+++ b/service/routes.py
@@ -73,13 +73,22 @@ def list_wishlists():
     """
     app.logger.info("Request to list all Wishlists")
 
-    wishlists = []
-
     # Check for query parameter to filter by customer_id
     customer_id = request.args.get("customer_id")
 
-    if customer_id:
-        app.logger.info("Filtering by customer_id: %s", customer_id)
+    name_query = request.args.get("name")
+
+    if name_query is not None and customer_id is not None:
+        app.logger.info(
+            "Filtering wishlists for customer_id: %s by name containing: %s",
+            customer_id,
+            name_query,
+        )
+        wishlists = Wishlists.find_all_by_customer_id_and_name_like(
+            int(customer_id), name_query
+        )
+    elif customer_id is not None:
+        app.logger.info("Returning all Wishlists for customer_id: %s", customer_id)
         wishlists = Wishlists.find_all_by_customer_id(int(customer_id))
     else:
         app.logger.info("Returning all Wishlists")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -373,6 +373,31 @@ class TestWishlistsModel(TestCase):
         found = Wishlists.find_all_by_customer_id(CUSTOMER_ID)
         self.assertEqual(len(found), 5)
 
+    def test_find_wishlist_by_customer_id_and_name_like(self):
+        """It should find Wishlists by customer_id and name containing a substring"""
+
+        # Create 5 Wishlists with names containing "My Wishlist"
+        for i in range(5):
+            resource = WishlistsFactory(name=f"My Wishlist {i}")
+            resource.create()
+
+        # Create 2 Wishlists with names containing "Other Wishlist"
+        for i in range(2):
+            resource = WishlistsFactory(name=f"Other Wishlist {i}")
+            resource.create()
+
+        # Find Wishlists by customer_id and name containing "My Wishlist"
+        found = Wishlists.find_all_by_customer_id_and_name_like(
+            CUSTOMER_ID, "My Wishlist"
+        )
+        self.assertEqual(len(found), 5)
+
+        # Find Wishlists by customer_id and name containing "Other Wishlist"
+        found = Wishlists.find_all_by_customer_id_and_name_like(
+            CUSTOMER_ID, "Other Wishlist"
+        )
+        self.assertEqual(len(found), 2)
+
     def test_find_all_by_wishlist_id(self):
         """It should find all WishlistItems by wishlist_id"""
         wishlists = []

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -160,6 +160,47 @@ class TestWishlistsService(TestCase):
         for wishlist in data:
             self.assertEqual(wishlist["customer_id"], CUSTOMER_ID)
 
+    def test_list_wishlists_by_customer_id_and_name_like(self):
+        """It should Get a list of Wishlists filtered by customer_id and name containing a substring"""
+        # Create wishlists with the default customer_id
+        for i in range(3):
+            wishlist = WishlistsFactory(name=f"My Wishlist {i}")
+            resp = self.client.post(
+                BASE_URL, json=wishlist.serialize(), content_type="application/json"
+            )
+            self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Create wishlists with the default customer_id
+        for i in range(2):
+            wishlist = WishlistsFactory(name=f"Other Wishlist {i}")
+            resp = self.client.post(
+                BASE_URL, json=wishlist.serialize(), content_type="application/json"
+            )
+            self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # Query for wishlists by customer_id and name containing a substring
+        resp = self.client.get(
+            BASE_URL, query_string={"customer_id": CUSTOMER_ID, "name": "My Wishlist"}
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 3)
+
+        for wishlist in data:
+            self.assertIn("My Wishlist", wishlist["name"])
+
+        # Query for wishlists by customer_id and name containing a substring
+        resp = self.client.get(
+            BASE_URL,
+            query_string={"customer_id": CUSTOMER_ID, "name": "Other Wishlist"},
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertEqual(len(data), 2)
+
+        for wishlist in data:
+            self.assertIn("Other Wishlist", wishlist["name"])
+
     def test_create_wishlist(self):
         """It should Create a new Wishlist"""
         wishlist = WishlistsFactory()


### PR DESCRIPTION
- Add support for filtering wishlists by customer_id and name substring
- Implement find_all_by_customer_id_and_name_like query method
- Add validation to ensure customer_id is provided when filtering by name
- Add tests for combined customer_id and name filtering

Resolve #41