### PR TITLE
Add flake8 and pylint linting to CI workflow

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -163,7 +163,7 @@ class TestWishlistsService(TestCase):
     def test_list_wishlists_by_customer_id_and_name_like(self):
         """It should Get a list of Wishlists filtered by customer_id and name containing a substring"""
         # Create wishlists with the default customer_id
-        for igiin range(3):
+        for i in range(3):
             wishlist = WishlistsFactory(name=f"My Wishlist {i}")
             resp = self.client.post(
                 BASE_URL, json=wishlist.serialize(), content_type="application/json"


### PR DESCRIPTION
Closes #67 

Added static analysis to CI workflow. Linting runs before unit tests and fails the workflow if issues are found.

### Changes
- Added "Run flake8 and pylint" step to ci.yml file:
  - First flake8 pass: Fatal errors (E9, F63, F7, F82)
  - Second flake8 pass: Complexity (max 10) and line length (max 127) 
  - pylint: PEP 8 enforcement with max-line-length=127
- Linting runs after dependency installation, before tests
- Flags match Makefile for consistency

### Acceptance Criteria
- CI runs linting before tests on every PR/push
- Workflow fails if flake8 or pylint report errors
- Linting errors are visible in workflow logs
- PR shows failed checks when linting fails

### Definition of Done
- CI logs show flake8 and pylint execution
- Linting commands match Makefile flags
- Workflow fails on lint errors (fail fast)
- Tests only run if linting passes

### Testing
- CI runs automatically on this PR
- To test locally: `make lint`