### PR TITLE
Add Dockerfile for Kubernetes deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.11-slim
+
+# Create working directory
+WORKDIR /app
+
+# Install system dependencies for PostgreSQL
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY Pipfile Pipfile.lock ./
+RUN pip install --upgrade pip pipenv && \
+    pipenv install --system --deploy
+
+# Copy application code
+COPY wsgi.py ./
+COPY service ./service
+
+# Expose port
+EXPOSE 8080
+
+# Run the service
+CMD ["gunicorn", "--bind=0.0.0.0:8080", "--log-level=info", "wsgi:app"]


### PR DESCRIPTION
Closes #75 

#### Changes
- Added production `Dockerfile` to enable `make build` workflow
- Installs PostgreSQL dependencies for `psycopg` binary
- Runs service with gunicorn on port 8080

#### Testing
Verified all Makefile targets work:
- `make cluster` - creates K3D cluster with registry
- `make build` - builds wishlists:1.0 image
- `make push` - pushes to local registry
- `make deploy` - deploys to Kubernetes

#### Acceptance Criteria
- all `make` works