### PR TITLE
Enable cascade delete for wishlist items

### DIFF
--- a/service/models/wishlist_items.py
+++ b/service/models/wishlist_items.py
@@ -31,7 +31,9 @@ class WishlistItems(db.Model, PersistentBase):
 
     __tablename__ = "wishlist_items"
 
-    wishlist_id = db.Column(db.Integer, db.ForeignKey("wishlists.id"), primary_key=True)
+    wishlist_id = db.Column(
+        db.Integer, db.ForeignKey("wishlists.id", ondelete="CASCADE"), primary_key=True
+    )
     product_id = db.Column(db.Integer, primary_key=True)
     description = db.Column(db.String(255))
     position = db.Column(db.Integer, nullable=False)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -720,3 +720,18 @@ class TestWishlistsModel(TestCase):
 
         with self.assertRaises(DataValidationError):
             item.update()
+
+    def test_delete_nonempty_wishlist(self):
+        """It should delete a Wishlist with items in it"""
+        wishlist = WishlistsFactory()
+        wishlist.create()
+        self.assertIsNotNone(wishlist.id)
+        item = WishlistItemsFactory(wishlist_id=wishlist.id)
+        item.create()
+        self.assertIsNotNone(item.wishlist_id)
+        self.assertIsNotNone(item.product_id)
+        found_items = WishlistItems.find_all_by_wishlist_id(wishlist.id)
+        self.assertEqual(len(found_items), 1)
+        wishlist.delete()
+        found = Wishlists.find_by_id(wishlist.id)
+        self.assertIsNone(found)


### PR DESCRIPTION
Added 'ondelete="CASCADE"' to the wishlist_id foreign key in WishlistItems to ensure items are deleted when their parent wishlist is removed. Added a test to verify that deleting a wishlist with items also deletes the associated items.

Resolves #148 