### PR TITLE
Add event listener and triggers for CD pipeline

### DIFF
--- a/.tekton/events/event_listener.yaml
+++ b/.tekton/events/event_listener.yaml
@@ -1,0 +1,8 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: cd-listener
+spec:
+  serviceAccountName: pipeline
+  triggers:
+    - triggerRef: cd-trigger

--- a/.tekton/events/trigger.yaml
+++ b/.tekton/events/trigger.yaml
@@ -1,0 +1,10 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: cd-trigger
+spec:
+  serviceAccountName: pipeline
+  bindings:
+    - ref: cd-binding
+  template:
+    ref: cd-template

--- a/.tekton/events/trigger_binding.yaml
+++ b/.tekton/events/trigger_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: cd-binding
+spec:
+  params:
+    - name: git-repo-url
+      value: $(body.repository.html_url)
+    - name: git-repo-name
+      value: $(body.repository.name)
+    - name: git-revision
+      value: $(body.head_commit.id)

--- a/.tekton/events/trigger_template.yaml
+++ b/.tekton/events/trigger_template.yaml
@@ -1,0 +1,38 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: cd-template
+spec:
+  params:
+    - name: git-repo-url
+      description: The git repository url
+    - name: git-revision
+      description: The git revision
+      default: master
+    - name: git-repo-name
+      description: The name of the deployment to be created / patched
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: cd-pipeline-$(tt.params.git-repo-name)-
+      spec:
+        serviceAccountName: pipeline
+        pipelineRef:
+          name: cd-pipeline
+        params:
+          - name: APP_NAME
+            value: $(tt.params.git-repo-name)
+          - name: GIT_REPO
+            value: $(tt.params.git-repo-url)
+          - name: IMAGE_NAME
+            value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(tt.params.git-repo-name):$(tt.params.git-revision)
+        workspaces:
+          - name: pipeline-workspace
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi


### PR DESCRIPTION
Implements Issue #112: Set Up Event Listener and Triggers

To enable automatic pipeline triggers, a team admin needs to configure the GitHub webhook:
   
   Webhook Settings:
   Payload URL: `https://cd-pipeline-yw9153-dev.apps.rm2.thpm.p1.openshiftapps.com`
    Content type: `application/json`
   events: Just the push event
   
  Files Added
   `.tekton/events/event_listener.yaml`
   `.tekton/events/trigger.yaml`
   `.tekton/events/trigger_binding.yaml`
   `.tekton/events/trigger_template.yaml`
   

Closes #112