### PR TITLE
Rename wishlist update date field for consistency

### DIFF
--- a/service/static/index.html
+++ b/service/static/index.html
@@ -84,9 +84,9 @@
 
             <!-- UPDATED DATE -->
              <div class="form-group">
-              <label class="control-label col-sm-2" for="wishlist_update_date">Update Date:</label>
+              <label class="control-label col-sm-2" for="wishlist_updated_date">Update Date:</label>
               <div class="col-sm-10">
-                <input type="text" class="form-control" id="wishlist_update_date" placeholder="Auto-generated update_date" readonly>
+                <input type="text" class="form-control" id="wishlist_updated_date" placeholder="Auto-generated updated_date" readonly>
               </div>
             </div>
 


### PR DESCRIPTION
Changed 'wishlist_update_date' to 'wishlist_updated_date' in the index.html form to match the database field naming.

Resolves #154 