### PR TITLE
Add Behave pipeline defaults and sync updated_date field

### DIFF
--- a/.tekton/events/trigger_template.yaml
+++ b/.tekton/events/trigger_template.yaml
@@ -11,6 +11,9 @@ spec:
       default: master
     - name: git-repo-name
       description: The name of the deployment to be created / patched
+    - name: base-url
+      description: Public route of the deployed application for Behave tests
+      default: "https://wishlists-yw9153-dev.apps.rm2.thpm.p1.openshiftapps.com/"
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
@@ -27,6 +30,8 @@ spec:
             value: $(tt.params.git-repo-url)
           - name: IMAGE_NAME
             value: image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(tt.params.git-repo-name):$(tt.params.git-revision)
+          - name: BASE_URL
+            value: $(tt.params.base-url)
         workspaces:
           - name: pipeline-workspace
             volumeClaimTemplate:

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -15,7 +15,11 @@ spec:
       description: Name of the application
       name: APP_NAME
       type: string
-    - default: 'image-registry.openshift-image-registry.svc:5000/$ (context.pipelineRun.namespace)/$(params.APP_NAME):latest'
+    - default: 'https://wishlists-yw9153-dev.apps.rm2.thpm.p1.openshiftapps.com/'
+      description: Public route of the deployed application for Behave tests
+      name: BASE_URL
+      type: string
+    - default: 'image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/$(params.APP_NAME):latest'
       description: The name of the image to build
       name: IMAGE_NAME
       type: string
@@ -143,12 +147,28 @@ spec:
         - name: image-name
           value: $(params.IMAGE_NAME)
         - name: manifest-dir
-          value: k8s
+          value: k8s/wishlists
       runAfter:
         - buildah
       taskRef:
         kind: Task
         name: deploy-image
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+    - name: behave
+      params:
+        - name: base-url
+          value: $(params.BASE_URL)
+        - name: wait-seconds
+          value: "60"
+        - name: driver
+          value: "chrome"
+      runAfter:
+        - deploy-image
+      taskRef:
+        kind: Task
+        name: behave
       workspaces:
         - name: source
           workspace: pipeline-workspace

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -84,9 +84,9 @@
 
             <!-- UPDATED DATE -->
              <div class="form-group">
-              <label class="control-label col-sm-2" for="wishlist_update_date">Update Date:</label>
+              <label class="control-label col-sm-2" for="wishlist_updated_date">Update Date:</label>
               <div class="col-sm-10">
-                <input type="text" class="form-control" id="wishlist_update_date" placeholder="Auto-generated update_date" readonly>
+                <input type="text" class="form-control" id="wishlist_updated_date" placeholder="Auto-generated updated_date" readonly>
               </div>
             </div>
 


### PR DESCRIPTION
- Add BASE_URL default (live OpenShift route) and propagate through Tekton pipeline/trigger for Behave UI tests.
- Keep Behave task wired after deploy; fix pipeline manifest path and image name template per upstream.
- Align updated_date field IDs in the UI with the JS handlers.

Testing
- DATABASE_URI=postgresql+psycopg://postgres:postgres@localhost:5432/testdb pytest -q --disable-warnings
- Behave: BASE_URL=https://wishlists-yw9153-dev.apps.rm2.thpm.p1.openshiftapps.com/ DRIVER=chrome WAIT_SECONDS=60 pipenv run behave 

Closes #111 
